### PR TITLE
Update changelog with 1.0.0 entry

### DIFF
--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -5,7 +5,14 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
-    {
+  {
+    version: '0.10.0',
+    date: '2026-04-09',
+    changes: [
+      'Reduced database load — Pi clients no longer trigger unnecessary queries when the playlist has not changed.',
+    ],
+  },
+  {
     version: '0.9.0',
     date: '2026-03-26',
     changes: [


### PR DESCRIPTION
Add a new 1.0.0 changelog entry describing a reduction in database load
when Pi clients do not trigger queries. This keeps the JSON changelog
simple and highlights the noticeable effect of the update for users and
maintainers.